### PR TITLE
Pydantic-based schema: consistent use of camelCase

### DIFF
--- a/chemicaljson.py
+++ b/chemicaljson.py
@@ -20,9 +20,9 @@ class Coords(BaseModel):
     Length must match the number of atoms*3 (x, y, z).
     """
 
-    field_3d: List[float] = Field(..., alias="3d", description="List of 3d Cartesian coordinates (in Angstrom) for the atoms [ x, y, z, x, y, z, ... ]")
-    field_3dFractional: Optional[List[float]] = Field(None, alias="3dFractional", description="Optional list of 3d fractional coordinates for the atoms [ x, y, z, x, y, z, ... ]")
-    field_3dSets: Optional[List[List[float]]] = Field(None, alias="3dSets", description="Optional list of lists of 3d Cartesian coordinates (in Angstrom) for the atoms [ [x, y, z], [x, y, z], ... ]")
+    field3d: List[float] = Field(..., alias="3d", description="List of 3d Cartesian coordinates (in Angstrom) for the atoms [ x, y, z, x, y, z, ... ]")
+    field3dFractional: Optional[List[float]] = Field(None, alias="3dFractional", description="Optional list of 3d fractional coordinates for the atoms [ x, y, z, x, y, z, ... ]")
+    field3dSets: Optional[List[List[float]]] = Field(None, alias="3dSets", description="Optional list of lists of 3d Cartesian coordinates (in Angstrom) for the atoms [ [x, y, z], [x, y, z], ... ]")
 
 
 class Atoms(BaseModel):
@@ -144,7 +144,7 @@ class PartialCharges(BaseModel):
     - "Gasteiger": [ 0.01, 0.02, 0.03, ... ]
     """
 
-    Mulliken: List[float]
+    mulliken: List[float]
 
 
 class UnitCell(BaseModel):
@@ -189,21 +189,21 @@ class Enable(BaseModel):
     Length of each much match the number of layers.
     """
 
-    Ball_and_Stick: Optional[List[bool]] = Field(alias="Ball and Stick")
-    Cartoons: Optional[List[bool]]
-    Close_Contacts: Optional[List[bool]] = Field(alias="Close Contacts")
-    Labels: Optional[List[bool]]
-    Licorice: Optional[List[bool]]
-    Van_der_Waals: Optional[List[bool]] = Field(alias="Van der Waals")
-    Wireframe: Optional[List[bool]]
+    ballAndStick: Optional[List[bool]] = Field(alias="Ball and Stick")
+    cartoons: Optional[List[bool]]
+    closeContacts: Optional[List[bool]] = Field(alias="Close Contacts")
+    labels: Optional[List[bool]]
+    licorice: Optional[List[bool]]
+    vanDerWaals: Optional[List[bool]] = Field(alias="Van der Waals")
+    wireframe: Optional[List[bool]]
 
 
 class Settings(BaseModel):
     """Settings for the render types. (Optional)"""
 
-    Ball_and_Stick: Optional[List[str]] = Field(alias="Ball and Stick", description="Settings for the Ball and Stick rendering type")
-    Cartoons: Optional[List[str]]
-    Wireframe: Optional[List[str]]
+    ballAndStick: Optional[List[str]] = Field(alias="Ball and Stick", description="Settings for the Ball and Stick rendering type")
+    cartoons: Optional[List[str]]
+    wireframe: Optional[List[str]]
 
 
 class Layer(BaseModel):

--- a/cjson.schema
+++ b/cjson.schema
@@ -302,7 +302,7 @@
       "description": "Partial charges for the atoms in the molecule. (Optional)\n\nKeys represent the partial charge method, followed by the computed partial charges.\ne.g.\n- \"Mulliken\": [ 0.01, 0.02, 0.03, ... ]\n- \"Gasteiger\": [ 0.01, 0.02, 0.03, ... ]",
       "type": "object",
       "properties": {
-        "Mulliken": {
+        "mulliken": {
           "title": "Mulliken",
           "type": "array",
           "items": {
@@ -311,7 +311,7 @@
         }
       },
       "required": [
-        "Mulliken"
+        "mulliken"
       ]
     },
     "Vibrations": {
@@ -441,7 +441,7 @@
             "type": "boolean"
           }
         },
-        "Cartoons": {
+        "cartoons": {
           "title": "Cartoons",
           "type": "array",
           "items": {
@@ -455,14 +455,14 @@
             "type": "boolean"
           }
         },
-        "Labels": {
+        "labels": {
           "title": "Labels",
           "type": "array",
           "items": {
             "type": "boolean"
           }
         },
-        "Licorice": {
+        "licorice": {
           "title": "Licorice",
           "type": "array",
           "items": {
@@ -476,7 +476,7 @@
             "type": "boolean"
           }
         },
-        "Wireframe": {
+        "wireframe": {
           "title": "Wireframe",
           "type": "array",
           "items": {
@@ -498,14 +498,14 @@
             "type": "string"
           }
         },
-        "Cartoons": {
+        "cartoons": {
           "title": "Cartoons",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "Wireframe": {
+        "wireframe": {
           "title": "Wireframe",
           "type": "array",
           "items": {


### PR DESCRIPTION
This makes all attributes in schema follow the camelCase convention of JSON. It doesn't change attributes in any other ways (additions, modifications, or documentation).