### PR TITLE
refactor: migrate pydantic from v1 to v2

### DIFF
--- a/chemicaljson.py
+++ b/chemicaljson.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import json
 from typing import List, Optional
 
-from pydantic.v1 import BaseModel, Field
+from pydantic import BaseModel, Field
 
 
 class Elements(BaseModel):
@@ -178,7 +179,7 @@ class UnitCell(BaseModel):
     beta: float = Field(..., description="Unit cell beta angle (in degrees).")
     gamma: float = Field(..., description="Unit cell gamma angle (in degrees).")
     cellVectors: Optional[List[float]] = Field(
-        min_items=9, max_items=9, default_factory=lambda: [0.0 for _ in range(9)], description="Optional list of cell vectors (in Angstrom): [ x1, y1, z1, x2, y2, z2, ... ]"
+        min_length=9, max_length=9, default_factory=lambda: [0.0 for _ in range(9)], description="Optional list of cell vectors (in Angstrom): [ x1, y1, z1, x2, y2, z2, ... ]"
     )
 
 
@@ -194,9 +195,9 @@ class Vibrations(BaseModel):
     frequencies: List[float] = Field(... , description="List of frequencies (in cm-1) for the vibrations.")
     intensities: List[float] = Field(... , description="List of IR intensities for the vibrations.")
     eigenVectors: List[List[float]] = Field(..., description="List of eigenvectors (displacements in Angstroms) for the vibrations.")
-    ramanIntensities: Optional[List[float]]
-    symmetries: Optional[List[str]]
-    modes: Optional[List[int]]
+    ramanIntensities: Optional[List[float]] = None
+    symmetries: Optional[List[str]] = None
+    modes: Optional[List[int]] = None
 
 
 class Enable(BaseModel):
@@ -205,21 +206,21 @@ class Enable(BaseModel):
     Length of each much match the number of layers.
     """
 
-    ballAndStick: Optional[List[bool]] = Field(alias="Ball and Stick")
-    cartoons: Optional[List[bool]]
-    closeContacts: Optional[List[bool]] = Field(alias="Close Contacts")
-    labels: Optional[List[bool]]
-    licorice: Optional[List[bool]]
-    vanDerWaals: Optional[List[bool]] = Field(alias="Van der Waals")
-    wireframe: Optional[List[bool]]
+    ballAndStick: Optional[List[bool]] = Field(None, alias="Ball and Stick")
+    cartoons: Optional[List[bool]] = None
+    closeContacts: Optional[List[bool]] = Field(None, alias="Close Contacts")
+    labels: Optional[List[bool]] = None
+    licorice: Optional[List[bool]] = None
+    vanDerWaals: Optional[List[bool]] = Field(None, alias="Van der Waals")
+    wireframe: Optional[List[bool]] = None
 
 
 class Settings(BaseModel):
     """Settings for the render types. (Optional)"""
 
-    ballAndStick: Optional[List[str]] = Field(alias="Ball and Stick", description="Settings for the Ball and Stick rendering type")
-    cartoons: Optional[List[str]]
-    wireframe: Optional[List[str]]
+    ballAndStick: Optional[List[str]] = Field(None, alias="Ball and Stick", description="Settings for the Ball and Stick rendering type")
+    cartoons: Optional[List[str]] = None
+    wireframe: Optional[List[str]] = None
 
 
 class Layer(BaseModel):
@@ -273,5 +274,5 @@ class CJSONModel(BaseModel):
 
 if __name__ == "__main__":
     with open("cjson.schema", "w") as handle:
-        handle.write(CJSONModel.schema_json(indent=2))
+        handle.write(json.dumps(CJSONModel.model_json_schema(), indent=2))
         handle.write("\n")

--- a/cjson.schema
+++ b/cjson.schema
@@ -1,459 +1,909 @@
 {
-  "title": "CJSONModel",
-  "description": "Full Chemical JSON model.\n\nA Chemical JSON (CJSON) model is intended to represent one molecular or periodic system.\nCatenating multiple systems will result in invalid JSON - store separate systems as\nseparate files / JSON entries.\n\nAttributes:\n    vibrations: Vibrations object. Optional.\n    unitCell: UnitCell object. Optional.\n    layer: Layer object. Optional (used by the GUI for rendering / settings)\n    basisSet: BasisSet object. Optional.\n    orbitals: Orbitals object. Optional. Requires BasisSet to be present.",
-  "type": "object",
-  "properties": {
-    "chemicalJson": {
-      "title": "Chemicaljson",
-      "description": "Version number of the Chemical JSON format. Currently 1. Only changed for backwards-incompatible changes to the schema.",
-      "default": 1,
-      "type": "integer"
-    },
-    "atoms": {
-      "title": "Atoms",
-      "description": "Atoms object, describing the atoms in this system.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Atoms"
-        }
-      ]
-    },
-    "name": {
-      "title": "Name",
-      "description": "Optional name / title for the molecule",
-      "type": "string"
-    },
-    "inchi": {
-      "title": "Inchi",
-      "description": "Optional InChI descriptor for the molecule",
-      "type": "string"
-    },
-    "formula": {
-      "title": "Formula",
-      "description": "Optional chemical formula in Hill order",
-      "type": "string"
-    },
-    "bonds": {
-      "title": "Bonds",
-      "description": "Optional Bonds object, describing covalent bonds",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Bonds"
-        }
-      ]
-    },
-    "properties": {
-      "title": "Properties",
-      "description": "Optional free-form Properties, including total charge and total spin multiplicity.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Properties"
-        }
-      ]
-    },
-    "inputParameters": {
-      "title": "Inputparameters",
-      "description": "Optional InputParameters object, including calculation metadata such as basis set, job type, etc.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/InputParameters"
-        }
-      ]
-    },
-    "metadata": {
-      "title": "Metadata",
-      "description": "Optional metadata object, including calculation details which do not directly impact results",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Metadata"
-        }
-      ]
-    },
-    "partialCharges": {
-      "title": "Partialcharges",
-      "description": "Optional PartialCharges object. Includes atomic partial charges and population analysis.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/PartialCharges"
-        }
-      ]
-    },
-    "vibrations": {
-      "$ref": "#/definitions/Vibrations"
-    },
-    "unitCell": {
-      "$ref": "#/definitions/UnitCell"
-    },
-    "layer": {
-      "$ref": "#/definitions/Layer"
-    },
-    "basisSet": {
-      "$ref": "#/definitions/BasisSet"
-    },
-    "orbitals": {
-      "$ref": "#/definitions/Orbitals"
-    },
-    "spectra": {
-      "$ref": "#/definitions/Spectra"
-    }
-  },
-  "required": [
-    "atoms"
-  ],
-  "definitions": {
-    "Elements": {
-      "title": "Elements",
-      "description": "List of elements for the atoms in the molecule.\n\nLength must match the number of atoms.",
-      "type": "object",
-      "properties": {
-        "number": {
-          "title": "Number",
-          "description": "Required list of atomic numbers for the atoms in this file.",
-          "type": "array",
-          "items": {
-            "type": "integer"
-          }
-        }
-      },
-      "required": [
-        "number"
-      ]
-    },
-    "Coords": {
-      "title": "Coords",
-      "description": "Coordinates for the atoms in the molecule.\n\nLength must match the number of atoms*3 (x, y, z).",
-      "type": "object",
-      "properties": {
-        "3d": {
-          "title": "3D",
-          "description": "List of 3d Cartesian coordinates (in Angstrom) for the atoms [ x, y, z, x, y, z, ... ]",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        },
-        "3dFractional": {
-          "title": "3Dfractional",
-          "description": "Optional list of 3d fractional coordinates for the atoms [ x, y, z, x, y, z, ... ]",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        },
-        "3dSets": {
-          "title": "3Dsets",
-          "description": "Optional list of lists of 3d Cartesian coordinates (in Angstrom) for the atoms [ [x, y, z], [x, y, z], ... ]",
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "number"
-            }
-          }
-        }
-      },
-      "required": [
-        "3d"
-      ]
-    },
+  "$defs": {
     "Atoms": {
-      "title": "Atoms",
       "description": "Atoms in the molecule.",
-      "type": "object",
       "properties": {
         "elements": {
-          "title": "Elements",
-          "description": "List of atomic numbers for the atoms.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Elements"
-            }
-          ]
+          "$ref": "#/$defs/Elements",
+          "description": "List of atomic numbers for the atoms."
         },
         "coords": {
-          "title": "Coords",
-          "description": "List of coordinates.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Coords"
-            }
-          ]
+          "$ref": "#/$defs/Coords",
+          "description": "List of coordinates."
         },
         "formalCharges": {
-          "title": "Formalcharges",
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "Optional list of formal charges for the atoms.",
-          "type": "array",
-          "items": {
-            "type": "integer"
-          }
+          "title": "Formalcharges"
         },
         "labels": {
-          "title": "Labels",
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "Optional list of custom labels for atoms (e.g., 'R' / 'S' or '0.12', etc.)",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "title": "Labels"
         },
         "layer": {
-          "title": "Layer",
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "Optional list of layer numbers for the atoms (generally just 1 for most molecules).",
-          "type": "array",
-          "items": {
-            "type": "integer"
-          }
+          "title": "Layer"
         }
       },
       "required": [
         "elements",
         "coords"
-      ]
+      ],
+      "title": "Atoms",
+      "type": "object"
     },
-    "Connections": {
-      "title": "Connections",
-      "description": "Connections - list of connections between atom indices.\n\nLength must be the number of bonds * 2",
-      "type": "object",
+    "BasisSet": {
+      "description": "Basis Set information (optional)\n\nAt the moment, implied to be Gaussian basis sets.",
       "properties": {
-        "index": {
-          "title": "Index",
-          "type": "array",
+        "coefficients": {
+          "description": "List of coefficients for the basis functions.",
+          "items": {
+            "type": "number"
+          },
+          "title": "Coefficients",
+          "type": "array"
+        },
+        "exponents": {
+          "description": "List of exponents for the basis functions.",
+          "items": {
+            "type": "number"
+          },
+          "title": "Exponents",
+          "type": "array"
+        },
+        "primitivesPerShell": {
+          "description": "List of number of primitives per shell.",
           "items": {
             "type": "integer"
-          }
+          },
+          "title": "Primitivespershell",
+          "type": "array"
+        },
+        "shellToAtomMap": {
+          "description": "List of atom indices for the basis functions.",
+          "items": {
+            "type": "integer"
+          },
+          "title": "Shelltoatommap",
+          "type": "array"
+        },
+        "shellTypes": {
+          "description": "List of shell types for the basis functions (l-value, so s=0, p=1, d=2, etc.).",
+          "items": {
+            "type": "integer"
+          },
+          "title": "Shelltypes",
+          "type": "array"
         }
       },
       "required": [
-        "index"
-      ]
+        "coefficients",
+        "exponents",
+        "primitivesPerShell",
+        "shellToAtomMap",
+        "shellTypes"
+      ],
+      "title": "BasisSet",
+      "type": "object"
     },
     "Bonds": {
-      "title": "Bonds",
       "description": "Optional bonds between atoms, including connections and bond orders for the atoms in the molecule. (Optional)",
-      "type": "object",
       "properties": {
         "connections": {
-          "$ref": "#/definitions/Connections"
+          "$ref": "#/$defs/Connections"
         },
         "order": {
-          "title": "Order",
-          "type": "array",
           "items": {
             "type": "integer"
-          }
+          },
+          "title": "Order",
+          "type": "array"
         }
       },
       "required": [
         "connections",
         "order"
-      ]
+      ],
+      "title": "Bonds",
+      "type": "object"
     },
-    "Properties": {
-      "title": "Properties",
-      "description": "Properties of the molecule / system. (Optional)\n\nA set of key-value properties.",
-      "type": "object",
+    "Connections": {
+      "description": "Connections - list of connections between atom indices.\n\nLength must be the number of bonds * 2",
       "properties": {
-        "molecularMass": {
-          "title": "Molecularmass",
-          "type": "number"
-        },
-        "meltingPoint": {
-          "title": "Meltingpoint",
-          "type": "number"
-        },
-        "boilingPoint": {
-          "title": "Boilingpoint",
-          "type": "number"
-        },
-        "totalCharge": {
-          "title": "Totalcharge",
-          "description": "Total charge of the system. If omitted, assume 0 (charge neutral)",
-          "default": 0,
-          "type": "integer"
-        },
-        "totalSpinMultiplicity": {
-          "title": "Totalspinmultiplicity",
-          "description": "Total spin multiplicity of the system (2S+1, e.g., 1, 2, 3, etc.). If omitted, assume to be 1 (singlet)",
-          "default": 1,
-          "type": "integer"
-        },
-        "totalEnergy": {
-          "title": "Totalenergy",
-          "description": "Optional total energy of the system in eV",
-          "type": "number"
+        "index": {
+          "items": {
+            "type": "integer"
+          },
+          "title": "Index",
+          "type": "array"
         }
-      }
+      },
+      "required": [
+        "index"
+      ],
+      "title": "Connections",
+      "type": "object"
     },
-    "InputParameters": {
-      "title": "InputParameters",
-      "description": "Input parameters for the calculation. (Optional)\n\nAttributes:\n    basis: Basis set used for the calculation (e.g. \"6-31G(d)\" or \"Custom\").\n    dispersion: Dispersion correction used for the calculation (e.g. \"D3\" or \"D3BJ\")\n    functional: Functional used for the calculation if DFT (e.g. \"B3LYP\" or \"Custom\").\n    grid: Keyword describing the DFT grid keyword usedf if DFT.\n    memory: The amount of memory requested for the calculation.\n    processors: The number of processors requested for the calculation.\n    task: \"Energy\" or \"Optimize\" or \"Frequencies\" or \"Transition State\" or \"Custom\".\n    theory: Method used for the calculation (e.g. \"DFT\" or \"HF\" or \"MP2\").",
-      "type": "object",
+    "Coords": {
+      "description": "Coordinates for the atoms in the molecule.\n\nLength must match the number of atoms*3 (x, y, z).",
       "properties": {
-        "basis": {
-          "title": "Basis",
-          "type": "string"
-        },
-        "dispersion": {
-          "title": "Dispersion",
-          "type": "string"
-        },
-        "functional": {
-          "title": "Functional",
-          "type": "string"
-        },
-        "grid": {
-          "title": "Grid",
-          "type": "string"
-        },
-        "memory": {
-          "title": "Memory",
-          "type": "string"
-        },
-        "processors": {
-          "title": "Processors",
-          "type": "string"
-        },
-        "task": {
-          "title": "Task",
-          "type": "string"
-        },
-        "theory": {
-          "title": "Theory",
-          "type": "string"
-        }
-      }
-    },
-    "Metadata": {
-      "title": "Metadata",
-      "description": "Metadata for the calculation. (Optional)\n\nAttributes:\n    runDate: date calculation was done",
-      "type": "object",
-      "properties": {
-        "runDate": {
-          "title": "Rundate",
-          "type": "string"
-        }
-      }
-    },
-    "PartialCharges": {
-      "title": "PartialCharges",
-      "description": "Partial charges for the atoms in the molecule. (Optional)\n\nKeys represent the partial charge method, followed by the computed partial charges.\ne.g.\n- \"Mulliken\": [ 0.01, 0.02, 0.03, ... ]\n- \"Gasteiger\": [ 0.01, 0.02, 0.03, ... ]",
-      "type": "object",
-      "properties": {
-        "mulliken": {
-          "title": "Mulliken",
-          "type": "array",
+        "3d": {
+          "description": "List of 3d Cartesian coordinates (in Angstrom) for the atoms [ x, y, z, x, y, z, ... ]",
           "items": {
             "type": "number"
-          }
+          },
+          "title": "3D",
+          "type": "array"
+        },
+        "3dFractional": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional list of 3d fractional coordinates for the atoms [ x, y, z, x, y, z, ... ]",
+          "title": "3Dfractional"
+        },
+        "3dSets": {
+          "anyOf": [
+            {
+              "items": {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional list of lists of 3d Cartesian coordinates (in Angstrom) for the atoms [ [x, y, z], [x, y, z], ... ]",
+          "title": "3Dsets"
+        }
+      },
+      "required": [
+        "3d"
+      ],
+      "title": "Coords",
+      "type": "object"
+    },
+    "Electronic": {
+      "description": "Electronic spectra (optional)",
+      "properties": {
+        "energies": {
+          "description": "List of excitation energies for the electronic spectra (in eV)",
+          "items": {
+            "type": "number"
+          },
+          "title": "Energies",
+          "type": "array"
+        },
+        "intensities": {
+          "description": "List of intensities for the electronic spectra",
+          "items": {
+            "type": "number"
+          },
+          "title": "Intensities",
+          "type": "array"
+        },
+        "rotation": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional list of rotation angles for the CD spectra (in degrees)",
+          "title": "Rotation"
+        }
+      },
+      "required": [
+        "energies",
+        "intensities"
+      ],
+      "title": "Electronic",
+      "type": "object"
+    },
+    "Elements": {
+      "description": "List of elements for the atoms in the molecule.\n\nLength must match the number of atoms.",
+      "properties": {
+        "number": {
+          "description": "Required list of atomic numbers for the atoms in this file.",
+          "items": {
+            "type": "integer"
+          },
+          "title": "Number",
+          "type": "array"
+        }
+      },
+      "required": [
+        "number"
+      ],
+      "title": "Elements",
+      "type": "object"
+    },
+    "Enable": {
+      "description": "Optional enable flags for different render types for each layer\n\nLength of each much match the number of layers.",
+      "properties": {
+        "Ball and Stick": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "boolean"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ball And Stick"
+        },
+        "cartoons": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "boolean"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cartoons"
+        },
+        "Close Contacts": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "boolean"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Close Contacts"
+        },
+        "labels": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "boolean"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Labels"
+        },
+        "licorice": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "boolean"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Licorice"
+        },
+        "Van der Waals": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "boolean"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Van Der Waals"
+        },
+        "wireframe": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "boolean"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Wireframe"
+        }
+      },
+      "title": "Enable",
+      "type": "object"
+    },
+    "InputParameters": {
+      "description": "Input parameters for the calculation. (Optional)\n\nAttributes:\n    basis: Basis set used for the calculation (e.g. \"6-31G(d)\" or \"Custom\").\n    dispersion: Dispersion correction used for the calculation (e.g. \"D3\" or \"D3BJ\")\n    functional: Functional used for the calculation if DFT (e.g. \"B3LYP\" or \"Custom\").\n    grid: Keyword describing the DFT grid keyword usedf if DFT.\n    memory: The amount of memory requested for the calculation.\n    processors: The number of processors requested for the calculation.\n    task: \"Energy\" or \"Optimize\" or \"Frequencies\" or \"Transition State\" or \"Custom\".\n    theory: Method used for the calculation (e.g. \"DFT\" or \"HF\" or \"MP2\").",
+      "properties": {
+        "basis": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Basis"
+        },
+        "dispersion": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dispersion"
+        },
+        "functional": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Functional"
+        },
+        "grid": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Grid"
+        },
+        "memory": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Memory"
+        },
+        "processors": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Processors"
+        },
+        "task": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Task"
+        },
+        "theory": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Theory"
+        }
+      },
+      "title": "InputParameters",
+      "type": "object"
+    },
+    "Layer": {
+      "description": "Layer settings for the molecule. (Optional)\n\nAttributes:\n    enable: Enable flags for different render types for each layer.\n    settings: Settings for the render types.\n    locked: List of locked layers (e.g., atoms in this layer should not change)\n    visible: List of visible layers (e.g., atoms in this layer should be visible / invisible)",
+      "properties": {
+        "enable": {
+          "$ref": "#/$defs/Enable"
+        },
+        "locked": {
+          "items": {
+            "type": "boolean"
+          },
+          "title": "Locked",
+          "type": "array"
+        },
+        "settings": {
+          "$ref": "#/$defs/Settings"
+        },
+        "visible": {
+          "items": {
+            "type": "boolean"
+          },
+          "title": "Visible",
+          "type": "array"
+        }
+      },
+      "required": [
+        "enable",
+        "locked",
+        "settings",
+        "visible"
+      ],
+      "title": "Layer",
+      "type": "object"
+    },
+    "Metadata": {
+      "description": "Metadata for the calculation. (Optional)\n\nAttributes:\n    runDate: date calculation was done",
+      "properties": {
+        "runDate": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rundate"
+        }
+      },
+      "title": "Metadata",
+      "type": "object"
+    },
+    "Nmr": {
+      "description": "NMR spectra (optional)",
+      "properties": {
+        "shifts": {
+          "description": "List of absolute chemical shifts for the NMR spectra (in ppm)",
+          "items": {
+            "type": "number"
+          },
+          "title": "Shifts",
+          "type": "array"
+        }
+      },
+      "required": [
+        "shifts"
+      ],
+      "title": "Nmr",
+      "type": "object"
+    },
+    "Orbitals": {
+      "description": "Information about molecular orbital energies and coefficients. (Optional)\n\nTo be useful, this should include basis set information, electronCount, energies, ",
+      "properties": {
+        "electronCount": {
+          "description": "Number of electrons in the species",
+          "title": "Electroncount",
+          "type": "integer"
+        },
+        "energies": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of energies for the molecular orbitals (in eV)",
+          "title": "Energies"
+        },
+        "moCoefficients": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of coefficients (flattened) for restricted molecular orbitals, i.e., alpha=beta (requires BasisSet to be present).",
+          "title": "Mocoefficients"
+        },
+        "alphaCoefficients": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of coefficients (flattened) for alpha open-shell orbitals, (requires BasisSet to be present).",
+          "title": "Alphacoefficients"
+        },
+        "betaCoefficients": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of coefficients (flattened) for beta open-shell orbitals, (requires BasisSet to be present).",
+          "title": "Betacoefficients"
+        },
+        "occupations": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of occupations for the molecular orbitals",
+          "title": "Occupations"
+        },
+        "symmetries": {
+          "anyOf": [
+            {
+              "items": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Symmetry of the orbital (e.g., a1, eg, t1g, etc.)",
+          "title": "Symmetries"
+        }
+      },
+      "required": [
+        "electronCount"
+      ],
+      "title": "Orbitals",
+      "type": "object"
+    },
+    "PartialCharges": {
+      "description": "Partial charges for the atoms in the molecule. (Optional)\n\nKeys represent the partial charge method, followed by the computed partial charges.\ne.g.\n- \"Mulliken\": [ 0.01, 0.02, 0.03, ... ]\n- \"Gasteiger\": [ 0.01, 0.02, 0.03, ... ]",
+      "properties": {
+        "mulliken": {
+          "items": {
+            "type": "number"
+          },
+          "title": "Mulliken",
+          "type": "array"
         }
       },
       "required": [
         "mulliken"
-      ]
+      ],
+      "title": "PartialCharges",
+      "type": "object"
     },
-    "Vibrations": {
-      "title": "Vibrations",
-      "description": "Vibrations for the molecule. (Optional)\n\nAttributes:\n    ramanIntensities: Optional list of Raman intensities for the vibrations.\n    modes: Optional list of mode numbers (e.g, [ 1, 2, 3, 4, 5, 6, ... ])\n    symmetries: Optional list of symmetries for the vibrations (e.g., 'a1g', 'eg' ...)",
-      "type": "object",
+    "Properties": {
+      "description": "Properties of the molecule / system. (Optional)\n\nA set of key-value properties.",
       "properties": {
-        "frequencies": {
-          "title": "Frequencies",
-          "description": "List of frequencies (in cm-1) for the vibrations.",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        },
-        "intensities": {
-          "title": "Intensities",
-          "description": "List of IR intensities for the vibrations.",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        },
-        "eigenVectors": {
-          "title": "Eigenvectors",
-          "description": "List of eigenvectors (displacements in Angstroms) for the vibrations.",
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
+        "molecularMass": {
+          "anyOf": [
+            {
               "type": "number"
+            },
+            {
+              "type": "null"
             }
-          }
+          ],
+          "default": null,
+          "title": "Molecularmass"
         },
-        "ramanIntensities": {
-          "title": "Ramanintensities",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
+        "meltingPoint": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Meltingpoint"
         },
-        "symmetries": {
-          "title": "Symmetries",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "boilingPoint": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Boilingpoint"
         },
-        "modes": {
-          "title": "Modes",
-          "type": "array",
-          "items": {
-            "type": "integer"
-          }
+        "totalCharge": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 0,
+          "description": "Total charge of the system. If omitted, assume 0 (charge neutral)",
+          "title": "Totalcharge"
+        },
+        "totalSpinMultiplicity": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 1,
+          "description": "Total spin multiplicity of the system (2S+1, e.g., 1, 2, 3, etc.). If omitted, assume to be 1 (singlet)",
+          "title": "Totalspinmultiplicity"
+        },
+        "totalEnergy": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional total energy of the system in eV",
+          "title": "Totalenergy"
         }
       },
-      "required": [
-        "frequencies",
-        "intensities",
-        "eigenVectors"
-      ]
+      "title": "Properties",
+      "type": "object"
+    },
+    "Settings": {
+      "description": "Settings for the render types. (Optional)",
+      "properties": {
+        "Ball and Stick": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Settings for the Ball and Stick rendering type",
+          "title": "Ball And Stick"
+        },
+        "cartoons": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cartoons"
+        },
+        "wireframe": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Wireframe"
+        }
+      },
+      "title": "Settings",
+      "type": "object"
+    },
+    "Spectra": {
+      "description": "Spectra (optional)\n\nObjects for non-vibrational spectra, including electronic, NMR, and other spectra.",
+      "properties": {
+        "electronic": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Electronic"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional electronic spectra"
+        },
+        "nmr": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Nmr"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional NMR spectra"
+        }
+      },
+      "title": "Spectra",
+      "type": "object"
     },
     "UnitCell": {
-      "title": "UnitCell",
       "description": "Unit cell for the system. (Optional)\n\nCurrent versions of Avogadro will output and preferentially use cellVectors,\nsince they fully specify the unit cell, but will also output a, b, c,\nalpha, beta, gamma parameters and use them if no cellVectors field is found.",
-      "type": "object",
       "properties": {
         "a": {
-          "title": "A",
           "description": "Unit cell a-axis length (in Angstrom).",
+          "title": "A",
           "type": "number"
         },
         "b": {
-          "title": "B",
           "description": "Unit cell b-axis length (in Angstrom).",
+          "title": "B",
           "type": "number"
         },
         "c": {
-          "title": "C",
           "description": "Unit cell c-axis length (in Angstrom).",
+          "title": "C",
           "type": "number"
         },
         "alpha": {
-          "title": "Alpha",
           "description": "Unit cell alpha angle (in degrees).",
+          "title": "Alpha",
           "type": "number"
         },
         "beta": {
-          "title": "Beta",
           "description": "Unit cell beta angle (in degrees).",
+          "title": "Beta",
           "type": "number"
         },
         "gamma": {
-          "title": "Gamma",
           "description": "Unit cell gamma angle (in degrees).",
+          "title": "Gamma",
           "type": "number"
         },
         "cellVectors": {
-          "title": "Cellvectors",
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 9,
+              "minItems": 9,
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "description": "Optional list of cell vectors (in Angstrom): [ x1, y1, z1, x2, y2, z2, ... ]",
-          "minItems": 9,
-          "maxItems": 9,
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
+          "title": "Cellvectors"
         }
       },
       "required": [
@@ -463,323 +913,276 @@
         "alpha",
         "beta",
         "gamma"
-      ]
+      ],
+      "title": "UnitCell",
+      "type": "object"
     },
-    "Enable": {
-      "title": "Enable",
-      "description": "Optional enable flags for different render types for each layer\n\nLength of each much match the number of layers.",
-      "type": "object",
+    "Vibrations": {
+      "description": "Vibrations for the molecule. (Optional)\n\nAttributes:\n    ramanIntensities: Optional list of Raman intensities for the vibrations.\n    modes: Optional list of mode numbers (e.g, [ 1, 2, 3, 4, 5, 6, ... ])\n    symmetries: Optional list of symmetries for the vibrations (e.g., 'a1g', 'eg' ...)",
       "properties": {
-        "Ball and Stick": {
-          "title": "Ball And Stick",
-          "type": "array",
-          "items": {
-            "type": "boolean"
-          }
-        },
-        "cartoons": {
-          "title": "Cartoons",
-          "type": "array",
-          "items": {
-            "type": "boolean"
-          }
-        },
-        "Close Contacts": {
-          "title": "Close Contacts",
-          "type": "array",
-          "items": {
-            "type": "boolean"
-          }
-        },
-        "labels": {
-          "title": "Labels",
-          "type": "array",
-          "items": {
-            "type": "boolean"
-          }
-        },
-        "licorice": {
-          "title": "Licorice",
-          "type": "array",
-          "items": {
-            "type": "boolean"
-          }
-        },
-        "Van der Waals": {
-          "title": "Van Der Waals",
-          "type": "array",
-          "items": {
-            "type": "boolean"
-          }
-        },
-        "wireframe": {
-          "title": "Wireframe",
-          "type": "array",
-          "items": {
-            "type": "boolean"
-          }
-        }
-      }
-    },
-    "Settings": {
-      "title": "Settings",
-      "description": "Settings for the render types. (Optional)",
-      "type": "object",
-      "properties": {
-        "Ball and Stick": {
-          "title": "Ball And Stick",
-          "description": "Settings for the Ball and Stick rendering type",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "cartoons": {
-          "title": "Cartoons",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "wireframe": {
-          "title": "Wireframe",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Layer": {
-      "title": "Layer",
-      "description": "Layer settings for the molecule. (Optional)\n\nAttributes:\n    enable: Enable flags for different render types for each layer.\n    settings: Settings for the render types.\n    locked: List of locked layers (e.g., atoms in this layer should not change)\n    visible: List of visible layers (e.g., atoms in this layer should be visible / invisible)",
-      "type": "object",
-      "properties": {
-        "enable": {
-          "$ref": "#/definitions/Enable"
-        },
-        "locked": {
-          "title": "Locked",
-          "type": "array",
-          "items": {
-            "type": "boolean"
-          }
-        },
-        "settings": {
-          "$ref": "#/definitions/Settings"
-        },
-        "visible": {
-          "title": "Visible",
-          "type": "array",
-          "items": {
-            "type": "boolean"
-          }
-        }
-      },
-      "required": [
-        "enable",
-        "locked",
-        "settings",
-        "visible"
-      ]
-    },
-    "BasisSet": {
-      "title": "BasisSet",
-      "description": "Basis Set information (optional)\n\nAt the moment, implied to be Gaussian basis sets.",
-      "type": "object",
-      "properties": {
-        "coefficients": {
-          "title": "Coefficients",
-          "description": "List of coefficients for the basis functions.",
-          "type": "array",
+        "frequencies": {
+          "description": "List of frequencies (in cm-1) for the vibrations.",
           "items": {
             "type": "number"
-          }
-        },
-        "exponents": {
-          "title": "Exponents",
-          "description": "List of exponents for the basis functions.",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        },
-        "primitivesPerShell": {
-          "title": "Primitivespershell",
-          "description": "List of number of primitives per shell.",
-          "type": "array",
-          "items": {
-            "type": "integer"
-          }
-        },
-        "shellToAtomMap": {
-          "title": "Shelltoatommap",
-          "description": "List of atom indices for the basis functions.",
-          "type": "array",
-          "items": {
-            "type": "integer"
-          }
-        },
-        "shellTypes": {
-          "title": "Shelltypes",
-          "description": "List of shell types for the basis functions (l-value, so s=0, p=1, d=2, etc.).",
-          "type": "array",
-          "items": {
-            "type": "integer"
-          }
-        }
-      },
-      "required": [
-        "coefficients",
-        "exponents",
-        "primitivesPerShell",
-        "shellToAtomMap",
-        "shellTypes"
-      ]
-    },
-    "Orbitals": {
-      "title": "Orbitals",
-      "description": "Information about molecular orbital energies and coefficients. (Optional)\n\nTo be useful, this should include basis set information, electronCount, energies, ",
-      "type": "object",
-      "properties": {
-        "electronCount": {
-          "title": "Electroncount",
-          "description": "Number of electrons in the species",
-          "type": "integer"
-        },
-        "energies": {
-          "title": "Energies",
-          "description": "List of energies for the molecular orbitals (in eV)",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        },
-        "moCoefficients": {
-          "title": "Mocoefficients",
-          "description": "List of coefficients (flattened) for restricted molecular orbitals, i.e., alpha=beta (requires BasisSet to be present).",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        },
-        "alphaCoefficients": {
-          "title": "Alphacoefficients",
-          "description": "List of coefficients (flattened) for alpha open-shell orbitals, (requires BasisSet to be present).",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        },
-        "betaCoefficients": {
-          "title": "Betacoefficients",
-          "description": "List of coefficients (flattened) for beta open-shell orbitals, (requires BasisSet to be present).",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        },
-        "occupations": {
-          "title": "Occupations",
-          "description": "List of occupations for the molecular orbitals",
-          "type": "array",
-          "items": {
-            "type": "integer"
-          }
-        },
-        "symmetries": {
-          "title": "Symmetries",
-          "description": "Symmetry of the orbital (e.g., a1, eg, t1g, etc.)",
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "required": [
-        "electronCount"
-      ]
-    },
-    "Electronic": {
-      "title": "Electronic",
-      "description": "Electronic spectra (optional)",
-      "type": "object",
-      "properties": {
-        "energies": {
-          "title": "Energies",
-          "description": "List of excitation energies for the electronic spectra (in eV)",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
+          },
+          "title": "Frequencies",
+          "type": "array"
         },
         "intensities": {
+          "description": "List of IR intensities for the vibrations.",
+          "items": {
+            "type": "number"
+          },
           "title": "Intensities",
-          "description": "List of intensities for the electronic spectra",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
+          "type": "array"
         },
-        "rotation": {
-          "title": "Rotation",
-          "description": "Optional list of rotation angles for the CD spectra (in degrees)",
-          "type": "array",
+        "eigenVectors": {
+          "description": "List of eigenvectors (displacements in Angstroms) for the vibrations.",
           "items": {
-            "type": "number"
-          }
+            "items": {
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "title": "Eigenvectors",
+          "type": "array"
+        },
+        "ramanIntensities": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ramanintensities"
+        },
+        "symmetries": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Symmetries"
+        },
+        "modes": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Modes"
         }
       },
       "required": [
-        "energies",
-        "intensities"
-      ]
-    },
-    "Nmr": {
-      "title": "Nmr",
-      "description": "NMR spectra (optional)",
-      "type": "object",
-      "properties": {
-        "shifts": {
-          "title": "Shifts",
-          "description": "List of absolute chemical shifts for the NMR spectra (in ppm)",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        }
-      },
-      "required": [
-        "shifts"
-      ]
-    },
-    "Spectra": {
-      "title": "Spectra",
-      "description": "Spectra (optional)\n\nObjects for non-vibrational spectra, including electronic, NMR, and other spectra.",
-      "type": "object",
-      "properties": {
-        "electronic": {
-          "title": "Electronic",
-          "description": "Optional electronic spectra",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Electronic"
-            }
-          ]
-        },
-        "nmr": {
-          "title": "Nmr",
-          "description": "Optional NMR spectra",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Nmr"
-            }
-          ]
-        }
-      }
+        "frequencies",
+        "intensities",
+        "eigenVectors"
+      ],
+      "title": "Vibrations",
+      "type": "object"
     }
-  }
+  },
+  "description": "Full Chemical JSON model.\n\nA Chemical JSON (CJSON) model is intended to represent one molecular or periodic system.\nCatenating multiple systems will result in invalid JSON - store separate systems as\nseparate files / JSON entries.\n\nAttributes:\n    vibrations: Vibrations object. Optional.\n    unitCell: UnitCell object. Optional.\n    layer: Layer object. Optional (used by the GUI for rendering / settings)\n    basisSet: BasisSet object. Optional.\n    orbitals: Orbitals object. Optional. Requires BasisSet to be present.",
+  "properties": {
+    "chemicalJson": {
+      "default": 1,
+      "description": "Version number of the Chemical JSON format. Currently 1. Only changed for backwards-incompatible changes to the schema.",
+      "title": "Chemicaljson",
+      "type": "integer"
+    },
+    "atoms": {
+      "$ref": "#/$defs/Atoms",
+      "description": "Atoms object, describing the atoms in this system."
+    },
+    "name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional name / title for the molecule",
+      "title": "Name"
+    },
+    "inchi": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional InChI descriptor for the molecule",
+      "title": "Inchi"
+    },
+    "formula": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional chemical formula in Hill order",
+      "title": "Formula"
+    },
+    "bonds": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Bonds"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional Bonds object, describing covalent bonds"
+    },
+    "properties": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Properties"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional free-form Properties, including total charge and total spin multiplicity."
+    },
+    "inputParameters": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/InputParameters"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional InputParameters object, including calculation metadata such as basis set, job type, etc."
+    },
+    "metadata": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Metadata"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional metadata object, including calculation details which do not directly impact results"
+    },
+    "partialCharges": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PartialCharges"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional PartialCharges object. Includes atomic partial charges and population analysis."
+    },
+    "vibrations": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Vibrations"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "unitCell": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UnitCell"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "layer": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Layer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "basisSet": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BasisSet"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "orbitals": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Orbitals"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "spectra": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Spectra"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "required": [
+    "atoms"
+  ],
+  "title": "CJSONModel",
+  "type": "object"
 }


### PR DESCRIPTION
Fix the following warning:

> UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.

- run bump-pydantic

    PydanticDeprecatedSince20: `min_items` is deprecated and will be
    removed, use `min_length` instead. Deprecated in Pydantic V2.0 to be
    removed in V3.0. See Pydantic V2 Migration Guide at
    https://errors.pydantic.dev/2.12/migration/

    PydanticDeprecatedSince20: `max_items` is deprecated and will be
    removed, use `max_length` instead. Deprecated in Pydantic V2.0 to be
    removed in V3.0. See Pydantic V2 Migration Guide at
    https://errors.pydantic.dev/2.12/migration/

- replace deprecated schema_json

    PydanticDeprecatedSince20: The `schema_json` method is deprecated;
    use `model_json_schema` and json.dumps instead. Deprecated in
    Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide
    at https://errors.pydantic.dev/2.12/migration/